### PR TITLE
Bumps version to reflect README changes.

### DIFF
--- a/srfi-121.meta
+++ b/srfi-121.meta
@@ -11,7 +11,7 @@
         "srfi-121.meta"
         "srfi-121.release-info"
         "LICENSE"
-        "README.md")
+        "README.org")
 
  (license "BSD")
  (category data)

--- a/srfi-121.release-info
+++ b/srfi-121.release-info
@@ -1,4 +1,5 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "1.2")
 (release "1.1")
 (release "1.0")

--- a/srfi-121.setup
+++ b/srfi-121.setup
@@ -9,4 +9,4 @@
 (install-extension
  'srfi-121
  `(,(dynld-name "srfi-121") ,(dynld-name "srfi-121.import"))
- '((version "1.1")))
+ '((version "1.2")))


### PR DESCRIPTION
This should correspond to a tag for `CHICKEN-1.2`.

I merely bumped the version here to reflect the new README distributed with the SRFI.
