### PR TITLE
Removes hardcoded .so extension

### DIFF
--- a/srfi-121.release-info
+++ b/srfi-121.release-info
@@ -1,5 +1,6 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "1.3")
 (release "1.2")
 (release "1.1")
 (release "1.0")

--- a/srfi-121.setup
+++ b/srfi-121.setup
@@ -3,10 +3,10 @@
 (define (dynld-name fn)
   (make-pathname #f fn ##sys#load-dynamic-extension))
 
-(compile -O3 -d0 -s -J "generators/generators.scm" -o srfi-121.so)
+(compile -O3 -d0 -s -J "generators/generators.scm" -o ,(dynld-name "srfi-121"))
 (compile -O2 -d0 -s "srfi-121.import.scm")
 
 (install-extension
  'srfi-121
  `(,(dynld-name "srfi-121") ,(dynld-name "srfi-121.import"))
- '((version "1.2")))
+ '((version "1.3")))


### PR DESCRIPTION
Also bumps versions to reflect this change.

Pointed out by Mario Goulart, this hardcoded file extension could cause issues (although on my tests with Windows, did nothing).

As with others, could you create a `CHICKEN-1.3` tag for this release?
