### PR TITLE
fix overconsumption in generator->reverse-list, as in generator->list

### DIFF
--- a/generators/generators-impl.scm
+++ b/generators/generators-impl.scm
@@ -311,31 +311,19 @@
           (truth value)
           (else (loop (value-gen) (truth-gen)))))))))
 
-
 ;; generator->list
 (define generator->list
-  (case-lambda ((gen) (generator->list gen +inf.0))
-               ((gen n)
-                (if (= 0 n)
-                  '()
-                  (let ((next (gen)))
-                   (if (eof-object? next)
-                     '()
-                     (cons next (generator->list gen (- n 1)))))))))
-
-
+  (case-lambda ((gen n)
+		(generator->list (gtake gen n)))
+               ((gen)
+		(reverse (generator->reverse-list gen)))))
 
 ;; generator->reverse-list
 (define generator->reverse-list
-  (case-lambda ((gen) (generator->reverse-list gen +inf.0))
-               ((gen n)
-                (define (build-reversed lst m)
-                  (let ((next (gen)))
-                   (if (or (eof-object? next)
-                           (>= m n))
-                     lst
-                     (build-reversed (cons next lst) (+ 1 m)))))
-                (build-reversed '() 0))))
+  (case-lambda ((gen n)
+		(generator->reverse-list (gtake gen n)))
+               ((gen)
+		(generator-fold cons '() gen))))
 
 ;; generator->vector
 (define generator->vector


### PR DESCRIPTION
Commit cd3f56f21b30597e260f3ef32b9cf87f358e05fe fixed a bug in generator->list, where the procedure could consume the wrong number of elements from the generator. It turns out that generator->reverse-list has the same bug. This patch fixes that.

While we're at it, we replaced each of these problematic loops with a one-liner that reuses other procedures. The old loops were not tail-recursive, so they allocated O(n) activation records. The new code avoids that so should perform better.
